### PR TITLE
Remove old kwargs and update defaults

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Update pip and install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r min_requirements.txt
+          python apply_requirements.py
       - name: Test with coverage
         run: python run_tests.py --coverage
       - uses: codecov/codecov-action@v1

--- a/apply_requirements.py
+++ b/apply_requirements.py
@@ -1,0 +1,24 @@
+import sys
+import subprocess
+
+pipcmd = [sys.executable, '-m', 'pip', 'install']
+
+def clone_euphonic():
+    subprocess.check_call(['git', 'clone', 'https://github.com/pace-neutrons/euphonic'])
+    subprocess.check_call(pipcmd + ['.'], cwd='euphonic')
+
+
+def install_requirements(requirements_file='min_requirements.txt'):
+    with open(requirements_file, 'r') as req:
+        packages = req.read().strip().split('\n')
+    euphonic = [pp for pp in packages if 'euphonic' in pp]
+    packages.pop(packages.index(euphonic[0]))
+    try:
+        subprocess.check_call(pipcmd + euphonic)
+    except subprocess.CalledProcessError:
+        clone_euphonic()
+    subprocess.check_call(pipcmd + packages)
+
+
+if __name__ == "__main__":
+    install_requirements()

--- a/apply_requirements.py
+++ b/apply_requirements.py
@@ -3,20 +3,24 @@ import subprocess
 
 pipcmd = [sys.executable, '-m', 'pip', 'install']
 
-def clone_euphonic():
+def clone_euphonic(suffix=''):
     subprocess.check_call(['git', 'clone', 'https://github.com/pace-neutrons/euphonic'])
-    subprocess.check_call(pipcmd + ['.'], cwd='euphonic')
+    subprocess.check_call(pipcmd + ['.' + suffix], cwd='euphonic')
 
 
 def install_requirements(requirements_file='min_requirements.txt'):
     with open(requirements_file, 'r') as req:
         packages = req.read().strip().split('\n')
-    euphonic = [pp for pp in packages if 'euphonic' in pp]
-    packages.pop(packages.index(euphonic[0]))
+    euphonic = [pp for pp in packages if 'euphonic' in pp][0]
+    packages.pop(packages.index(euphonic))
+    if '[' in euphonic and ']' in euphonic:
+        suffix = f"[{euphonic.split('[')[1].split(']')[0]}]"
+    else:
+        suffix = ''
     try:
-        subprocess.check_call(pipcmd + euphonic)
+        subprocess.check_call(pipcmd + [euphonic])
     except subprocess.CalledProcessError:
-        clone_euphonic()
+        clone_euphonic(suffix)
     subprocess.check_call(pipcmd + packages)
 
 

--- a/euphonic_sqw_models/euphonic_wrapper.py
+++ b/euphonic_sqw_models/euphonic_wrapper.py
@@ -45,7 +45,6 @@ class CoherentCrystal(object):
     reduce_qpts : boolean, optional
     use_c : boolean, optional
     n_threads : int, optional
-    fall_back_on_python : boolean, optional
         These are parameters used in the `calculate_qpoint_phonon_modes` method of ForceConstants
         Type `help(fc.calculate_qpoint_phonon_modes)` where fc is the ForceConstants object you created.
     """
@@ -55,7 +54,7 @@ class CoherentCrystal(object):
     defaults = {'debye_waller': None, 'debye_waller_grid': None, 'temperature': 0.0 * ureg('K'), 'bose': True,
                 'negative_e': False, 'conversion_mat': None, 'chunk': 5000, 'lim': np.inf, 'scattering_lengths': 'Sears1992',
                 'weights': None, 'asr': None, 'dipole': True, 'eta_scale': 1.0, 'splitting': True, 'insert_gamma': False, 
-                'reduce_qpts': True, 'use_c': False, 'n_threads': 1, 'fall_back_on_python': True, 'verbose': True}
+                'reduce_qpts': True, 'use_c': None, 'n_threads': None, 'verbose': True}
 
     def __init__(self, force_constants, **kwargs):
         for key, val in self.defaults.items():
@@ -145,7 +144,7 @@ class CoherentCrystal(object):
         return self.force_constants.calculate_qpoint_phonon_modes(qpts,
             weights=self.weights, asr=self.asr, dipole=self.dipole, eta_scale=self.eta_scale,
             splitting=self.splitting, insert_gamma=self.insert_gamma, reduce_qpts=self.reduce_qpts,
-            use_c=self.use_c, n_threads=self.n_threads, fall_back_on_python=self.fall_back_on_python)
+            use_c=self.use_c, n_threads=self.n_threads)
 
     def _calculate_debye_waller(self):
         if self.temperature <= 0.0:

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -1,3 +1,3 @@
-euphonic[phonopy_reader]>=0.4.0
+euphonic[phonopy_reader]>0.4.0
 pytest
 coverage

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,7 @@
 import pytest
 import coverage
 import argparse
+import sys
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -28,3 +29,5 @@ if __name__ == "__main__":
     if args_parsed.coverage:
         cov.stop()
         cov.xml_report(outfile='coverage.xml')
+
+    sys.exit(test_output)


### PR DESCRIPTION
Caused by this change: https://github.com/pace-neutrons/Euphonic/commit/6696045281af87e6009fdf74f19e9ae7c4894dfc, which has removed the need for the `fall_back_on_python` argument and has changed the defaults of the `use_c` and `n_threads` arguments to `calculate_qpoint_phonon_modes`.

This update is quite simple, but I'm creating this as a PR to raise the issue of updating dependent projects: should there be a formal workflow for this? e.g. should we have multiple parallel PRs making the relevant updates to each project? In that case, a useful feature for pace-integration could be to enable building from specified branches, maybe through build parameters? Or do we just wait until pace-integration fails and then make the required updates?

I don't know if this is the best place to have this conversation but I'm at least starting it here. Any thoughts and should anyone else be involved?