### PR TITLE
Allow frequency scaling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 `Unreleased <https://github.com/pace-neutrons/euphonic_sqw_models/compare/v0.4.0...HEAD>`_
 ----------
 
+- Improvements:
+
+  - There is a new ``frequency_scale=1.0`` argument to ``horace_disp`` which
+    allows the output frequencies to be scaled
+
+- Breaking changes:
+
+  - The ``pars=[]`` argument to ``horace_disp`` has been changed to
+    ``intensity_scale=1.0``
+
 `v0.4.0 <https://github.com/pace-neutrons/euphonic_sqw_models/compare/v0.3.0...0.4.0>`_
 ------
 

--- a/euphonic_sqw_models/euphonic_wrapper.py
+++ b/euphonic_sqw_models/euphonic_wrapper.py
@@ -137,9 +137,20 @@ class CoherentCrystal(object):
         sf : (n_modes,) tuple of (n_pts,) float ndarray
             The dynamical structure corresponding to phonon energies in w as a tuple of numpy float vectors
         """
-
-        intensity_scale = pars[0]
-        frequency_scale =  pars[1]
+        if not hasattr(pars, '__len__') or len(pars) == 1:
+            warnings.warn('horace_disp now requires pars of length 2: '
+                          'pars=[intensity_scale, frequency_scale], pars '
+                          'of length 1: pars=[intensity_scale] will stop '
+                          'working in a future release.',
+                          category=DeprecationWarning)
+            frequency_scale = 1.0
+            if hasattr(pars, '__len__'):
+                intensity_scale = pars[0]
+            else:
+                intensity_scale = pars
+        else:
+            intensity_scale = pars[0]
+            frequency_scale =  pars[1]
         if self.chunk > 0:
             lqh = len(qh)
             for i in range(int(np.ceil(lqh / self.chunk))):

--- a/euphonic_sqw_models/euphonic_wrapper.py
+++ b/euphonic_sqw_models/euphonic_wrapper.py
@@ -16,10 +16,9 @@ class CoherentCrystal(object):
 
     Methods
     -------
-    w, sf = horace_disp(qh, qk, ql, pars=[1.0, 1.0])
+    w, sf = horace_disp(qh, qk, ql, intensity_scale=1.0, frequency_scale=1.0)
         Calculates the phonon dispersion surfaces `w` and structure factor `sf` at the specified
-        (qh, qk, ql) points. The optional parameters `pars=[intensity_scale, frequency scale]`
-        is are the intensity and frequency scaling factors
+        (qh, qk, ql) points, with optional intensity and frequency scaling factors
 
     Attributes
     ----------
@@ -110,7 +109,7 @@ class CoherentCrystal(object):
             sf = np.hstack((sf, neg_sf))
         return w, sf
         
-    def horace_disp(self, qh, qk, ql, pars=[1.0, 1.0], *args, **kwargs):
+    def horace_disp(self, qh, qk, ql, intensity_scale=1.0, frequency_scale=1.0, *args, **kwargs):
         """
         Calculates the phonon dispersion surface for input qh, qk, and ql vectors for use with Horace
  
@@ -118,13 +117,11 @@ class CoherentCrystal(object):
         ----------
         qh, qk, ql : (n_pts,) float ndarray
             The q-points to calculate at as separate vectors
-        pars : Sequence[float, float]
-            Parameters for the calculation:
-                pars[0] = intensity scaling - factor to multiply the
-                          intensity by
-                pars[1] = frequency scaling - factor to multiply the phonon
-                          frequencies by, as DFT can often overestimate
-                          frequencies
+        intensity_scale : float
+            The factor to multiply the intensity by
+        frequency_scale : float
+                The factor to multiply the phonon frequencies
+                by, as DFT can often overestimate frequencies
         args: tuple
             Arguments passed directly to the convolution function
         kwargs : dict
@@ -137,20 +134,6 @@ class CoherentCrystal(object):
         sf : (n_modes,) tuple of (n_pts,) float ndarray
             The dynamical structure corresponding to phonon energies in w as a tuple of numpy float vectors
         """
-        if not hasattr(pars, '__len__') or len(pars) == 1:
-            warnings.warn('horace_disp now requires pars of length 2: '
-                          'pars=[intensity_scale, frequency_scale], pars '
-                          'of length 1: pars=[intensity_scale] will stop '
-                          'working in a future release.',
-                          category=DeprecationWarning)
-            frequency_scale = 1.0
-            if hasattr(pars, '__len__'):
-                intensity_scale = pars[0]
-            else:
-                intensity_scale = pars
-        else:
-            intensity_scale = pars[0]
-            frequency_scale =  pars[1]
         if self.chunk > 0:
             lqh = len(qh)
             for i in range(int(np.ceil(lqh / self.chunk))):

--- a/test/euphonic_horace_test.py
+++ b/test/euphonic_horace_test.py
@@ -183,9 +183,9 @@ def test_euphonic_sqw_models_pars(
     sf_summed = sum_degenerate_modes(expected_w, sf)
     expected_sf_summed = sum_degenerate_modes(expected_w, expected_sf)
     # Check that pars have scaled w and sf as expected
-    npt.assert_allclose(w, freqscale*expected_w, rtol=1e-5, atol=1e-2)
+    npt.assert_allclose(w, freqscale*expected_w, rtol=1e-5, atol=1e-2*freqscale)
     npt.assert_allclose(sf_summed, iscale*expected_sf_summed,
-                        rtol=1e-2, atol=1e-2)
+                        rtol=1e-2, atol=1e-2*iscale)
 
 
 @pytest.mark.parametrize("opt_dict", [{

--- a/test/euphonic_horace_test.py
+++ b/test/euphonic_horace_test.py
@@ -36,10 +36,13 @@ qpts = [[0.0,  0.0,  0.0],
         [0.0, -0.5,  0.0],
         [0.0,  0.0, -0.5],
         [1.0, -1.0, -1.0]]
+qpts = np.array(qpts)
 scattering_lengths = {'La': 8.24, 'Zr': 7.16, 'O': 5.803,
                       'Si': 4.1491, 'Na': 3.63, 'Cl': 9.577}
-scale = 1.0
-qpts = np.array(qpts)
+iscale = 1.0
+freq_scale = 1.0
+pars = [iscale, freq_scale]
+
 
 def parameter_generator():
     for tt in temp:
@@ -57,8 +60,8 @@ def parameter_generator():
                                        'conversion_mat': cmat,
                                        'lim': lm}
 
-def get_expected_output_filename(material_name, pars, opts):
-    fname = f"{material_name}_T{pars[0]}"
+def get_expected_output_filename(material_name, opts):
+    fname = f"{material_name}_T{opts['temperature']}"
     if opts.get('debye_waller_grid', None) is not None:
         fname += "_dw" + "".join([str(v) for v in opts['debye_waller_grid']])
     if opts.get('bose', None) is not None:
@@ -99,7 +102,7 @@ def calculate_w_sf(material_pars, material_constructor, par_dict):
     par_dict['asr'] = 'reciprocal'
     par_dict['scattering_lengths'] = scattering_lengths
     coherent_sqw = euphonic_sqw_models.CoherentCrystal(fc, **par_dict)
-    w, sf = coherent_sqw.horace_disp(qpts[:,0], qpts[:,1], qpts[:,2], scale)
+    w, sf = coherent_sqw.horace_disp(qpts[:,0], qpts[:,1], qpts[:,2], pars)
     w = np.array(w).T
     sf = np.array(sf).T
     # Ignore acoustic structure factors by setting to zero - their
@@ -130,7 +133,7 @@ def test_euphonic_sqw_models(par_dict):
         par_dict.pop('material'))
     expected_w, expected_sf = get_expected_w_sf(
         get_expected_output_filename(
-            material_name, [par_dict['temperature'], scale], par_dict))
+            material_name, par_dict))
 
     for run_par in run_pars:
         par_dict.update(run_par)
@@ -160,7 +163,7 @@ def test_sf_unit_change(par_dict):
     material_name, material_constructor, material_pars = tuple(
         par_dict.pop('material'))
     fname = get_expected_output_filename(
-            material_name, [par_dict['temperature'], scale], par_dict)
+            material_name, par_dict)
     expected_w, expected_sf = get_expected_w_sf(os.path.join(
         os.path.dirname(fname),
         f'old_units_{os.path.basename(fname)}'))

--- a/test/euphonic_horace_test.py
+++ b/test/euphonic_horace_test.py
@@ -181,6 +181,32 @@ def test_euphonic_sqw_models_pars(material, opt_dict, iscale, freqscale):
                         rtol=1e-2, atol=1e-2)
 
 
+@pytest.mark.parametrize("opt_dict", [{
+    'temperature': 300,
+    'debye_waller_grid': [6, 6, 6],
+    'negative_e': True,
+    'conversion_mat': (1./2)*np.array([[-1, 1, 1],
+                                       [1, -1, 1],
+                                       [1, 1, -1]])}])
+def test_using_length_1_pars_emits_deprecation_warning(opt_dict):
+    material_name, material_constructor, material_opts = materials[0]
+    opt_dict = {'temperature': 300,
+                'debye_waller_grid': [6, 6, 6],
+                'conversion_mat': (1./2)*np.array([[-1, 1, 1],
+                                                   [1, -1, 1],
+                                                   [1, 1, -1]])}
+    fc = material_constructor(**material_opts)
+    coherent_sqw = euphonic_sqw_models.CoherentCrystal(fc, **opt_dict)
+    with pytest.warns(DeprecationWarning):
+        w_1par, sf_1par = coherent_sqw.horace_disp(
+            qpts[:,0], qpts[:,1], qpts[:,2], [1.5])
+    # Also test that 1.0 is automatically set as frequency_scale
+    w_2par, sf_2par = coherent_sqw.horace_disp(
+        qpts[:,0], qpts[:,1], qpts[:,2], [1.5, 1.0])
+    npt.assert_allclose(w_1par, w_2par, rtol=1e-5, atol=1e-2)
+    npt.assert_allclose(sf_1par, sf_2par, rtol=1e-2, atol=1e-2)
+
+
 # Units of sf have changed, test the calculated and old expected
 # values are the same apart from a scale factor
 @pytest.mark.parametrize("material", materials)


### PR DESCRIPTION
Addresses https://github.com/pace-neutrons/horace-euphonic-interface/issues/13. I've just added the frequency_scale factor as another entry in the 'pars' list, as this seems to be the general pattern of dispreln functions for use with Horace, but I feel like it might become cumbersome if we add more parameters. Is there a way to do anything better with named parameters like `pars = {'intensity_scale', 2.0, 'frequency_scale', 0.9}` or would this mess with fitting or pace-python?

Some things left to do, once the interface has been confirmed:
- [x] Update changelog
- [x] Update horace-euphonic-interface, see https://github.com/pace-neutrons/horace-euphonic-interface/pull/16
- [x] Update pace-integration tests see https://github.com/pace-neutrons/pace-integration/tree/add_scaling_tests