### PR TITLE
Allow Euphonic ver to be specified in apply_requirements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019]
-        python: [3.6]
+        os: [ubuntu-latest, windows-latest]
+        python: [3.7]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,23 +10,33 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.7]
+        python_version: ['3.10']
+        euphonic_version: ['']
+        # Test lowest supported Python/Euphonic versions
+        include:
+          - os: ubuntu-latest
+            python_version: '3.7'
+            euphonic_version: '--version 0.6.0'
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.python_version }}
       - name: Update pip
+        shell: bash -l {0}
         run: python -m pip install --upgrade pip
       - name: Install basic Euphonic and dependencies and run tests
+        shell: bash -l {0}
         run: |
-          python apply_requirements.py
+          python apply_requirements.py ${{ matrix.euphonic_version }}
           python run_tests.py -m "not phonopy_reader" --coverage "coverage.xml"
       - name: Install Euphonic with phonopy_reader extra and run tests
+        shell: bash -l {0}
         run: |
-          python apply_requirements.py --extras phonopy_reader
+          python apply_requirements.py --extras phonopy_reader ${{ matrix.euphonic_version }}
           python run_tests.py -m "phonopy_reader" --coverage "coverage_phonopy_reader.xml"
       - uses: codecov/codecov-action@v1
         if: startsWith(matrix.os, 'ubuntu')

--- a/test/euphonic_horace_test.py
+++ b/test/euphonic_horace_test.py
@@ -271,7 +271,7 @@ def test_euphonic_sqw_models_pars(
     sf_summed = sum_degenerate_modes(expected_w, sf)
     expected_sf_summed = sum_degenerate_modes(expected_w, expected_sf)
     # Check that pars have scaled w and sf as expected
-    npt.assert_allclose(w, expected_w*freqscale, atol=1e-2*freqscale,
+    npt.assert_allclose(w, expected_w*freqscale, atol=1.5e-2*freqscale,
                         rtol=1e-5)
     npt.assert_allclose(sf_summed, iscale*expected_sf_summed,
                         rtol=1e-2, atol=1e-2*iscale)
@@ -318,7 +318,7 @@ def test_old_behaviour_single_parameter_sets_intensity_scale(opt_dict):
     sf_summed = sum_degenerate_modes(expected_w, sf)
     expected_sf_summed = sum_degenerate_modes(expected_w, expected_sf)
     # Check that pars have scaled w and sf as expected
-    npt.assert_allclose(w, expected_w, atol=1e-2, rtol=1e-5)
+    npt.assert_allclose(w, expected_w, atol=1.5e-2, rtol=1e-5)
     npt.assert_allclose(sf_summed, iscale*expected_sf_summed,
                         rtol=1e-2, atol=1e-2)
 
@@ -343,7 +343,7 @@ def test_sf_unit_change(material, opt_dict):
 
     w, sf = calculate_w_sf(material_opts, material_constructor, opt_dict)
 
-    npt.assert_allclose(w, expected_w, atol=1e-2, rtol=1e-5)
+    npt.assert_allclose(w, expected_w, atol=1.5e-2, rtol=1e-5)
 
     # Change in units angstrom**2 -> mbarn = 1e11. Change from sf per
     # unit cell to sf per atom = 1/n_atoms. Change from relative to


### PR DESCRIPTION
This allows us to test against both the newest (default behaviour) and a specific of Euphonic. Previously `apply_requirements.py` was supposed to install the lowest supported version of Euphonic but because it used `euphonic>=0.6.0` it was actually using the latest release version.