### PR TITLE
Update actions versions (Node.js 12 deprecation)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -38,7 +38,7 @@ jobs:
         run: |
           python apply_requirements.py --extras phonopy_reader ${{ matrix.euphonic_version }}
           python run_tests.py -m "phonopy_reader" --coverage "coverage_phonopy_reader.xml"
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
         if: startsWith(matrix.os, 'ubuntu')
         with:
           files: |


### PR DESCRIPTION
Currently am getting the following warning on Github Actions runners:
```
Node.js 12 actions are deprecated.
For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: conda-incubator/setup-miniconda, actions/upload-artifact, codecov/codecov-action, conda-incubator/setup-miniconda
```
setup-miniconda doesn't seem to have an update for that yet, but there is an issue to do this https://github.com/conda-incubator/setup-miniconda/issues issue 248. Opening this PR as a reminder for now and will merge once a new version of setup-miniconda has been released.

Tasks:
- [x] Rerun after a new setup-miniconda release