### PR TITLE
Automatic chunk calculation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,12 @@ jobs:
         shell: bash -l {0}
         run: |
           python apply_requirements.py ${{ matrix.euphonic_version }}
-          python run_tests.py -m "not phonopy_reader" --coverage "coverage.xml"
+          python run_tests.py -m "not (phonopy_reader or psutil)" --coverage "coverage.xml"
+      - name: Install psutil extra and run tests
+        shell: bash -l {0}
+        run: |
+          python -m pip install psutil
+          python run_tests.py -m "psutil" --coverage "coverage_psutil.xml"
       - name: Install Euphonic with phonopy_reader extra and run tests
         shell: bash -l {0}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,9 +25,11 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python_version }}
-      - name: Update pip
+      - name: Update pip, install test dependencies
         shell: bash -l {0}
-        run: python -m pip install --upgrade pip
+        run: |
+          python -m pip install --upgrade pip
+          python -mpip install -r test/ci_requirements.txt
       - name: Install basic Euphonic and dependencies and run tests
         shell: bash -l {0}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,12 +32,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python apply_requirements.py ${{ matrix.euphonic_version }}
-          python run_tests.py -m "not (phonopy_reader or psutil)" --coverage "coverage.xml"
-      - name: Install psutil extra and run tests
-        shell: bash -l {0}
-        run: |
-          python -m pip install psutil
-          python run_tests.py -m "psutil" --coverage "coverage_psutil.xml"
+          python run_tests.py -m "not phonopy_reader" --coverage "coverage.xml"
       - name: Install Euphonic with phonopy_reader extra and run tests
         shell: bash -l {0}
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,13 @@
 
   - ``n_threads`` is now explicitly named in the ``CoherentCrystal`` constructor arguments
     rather than being part of ``**kwargs``
+  - ``psutil`` has been added as an optional dependency
 
+- Improvements:
+
+  - If ``psutil`` is installed and ``chunk`` hasn't been provided, a recommended chunk
+    size will be calculated and set. If ``psutil`` is not installed, the default
+    chunk size is still ``5000``.
 
 `v0.5.2 <https://github.com/pace-neutrons/euphonic_sqw_models/compare/v0.5.1...v0.5.2>`_
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,13 +5,12 @@
 
   - ``n_threads`` is now explicitly named in the ``CoherentCrystal`` constructor arguments
     rather than being part of ``**kwargs``
-  - ``psutil`` has been added as an optional dependency
+  - ``psutil`` has been added as a dependency
 
 - Improvements:
 
-  - If ``psutil`` is installed and ``chunk`` hasn't been provided, a recommended chunk
-    size will be calculated and set. If ``psutil`` is not installed, the default
-    chunk size is still ``5000``.
+  - If ``chunk`` hasn't been provided to ``CoherentCrystal``, a recommended chunk
+    size will now be calculated and set based on available memory.
 
 `v0.5.2 <https://github.com/pace-neutrons/euphonic_sqw_models/compare/v0.5.1...v0.5.2>`_
 ------

--- a/euphonic_sqw_models/euphonic_wrapper.py
+++ b/euphonic_sqw_models/euphonic_wrapper.py
@@ -277,14 +277,14 @@ class CoherentCrystal(object):
             import psutil
         except ModuleNotFoundError:
             warnings.warn(
-                'Cannot import psutil to automatically estimate '
+                '\nCannot import psutil to automatically estimate '
                 'calculation chunk size. Setting chunk size to 5000. '
                 'Try installing psutil:\n '
                 'python -m pip install psutil')
             return 5000
         mem = psutil.virtual_memory().available
         evec_bytes_per_qpt = 16*(3*n_atoms)**2
-        chunk = int(mem/(2*evec_bytes_per_qpt))
+        chunk = int(mem/(10*evec_bytes_per_qpt))
         return chunk
 
     @property

--- a/euphonic_sqw_models/euphonic_wrapper.py
+++ b/euphonic_sqw_models/euphonic_wrapper.py
@@ -1,6 +1,7 @@
 import warnings
 from typing import Optional, Dict, Union, Tuple
 
+import psutil
 import numpy as np
 
 from euphonic import (ForceConstants, QpointPhononModes, DebyeWaller,
@@ -273,15 +274,6 @@ class CoherentCrystal(object):
 
     @staticmethod
     def get_optimum_chunk_size(n_atoms: int):
-        try:
-            import psutil
-        except ModuleNotFoundError:
-            warnings.warn(
-                '\nCannot import psutil to automatically estimate '
-                'calculation chunk size. Setting chunk size to 5000. '
-                'Try installing psutil:\n '
-                'python -m pip install psutil')
-            return 5000
         mem = psutil.virtual_memory().available
         evec_bytes_per_qpt = 16*(3*n_atoms)**2
         # Divide chunk by 10 for a conservative estimate

--- a/euphonic_sqw_models/euphonic_wrapper.py
+++ b/euphonic_sqw_models/euphonic_wrapper.py
@@ -284,6 +284,7 @@ class CoherentCrystal(object):
             return 5000
         mem = psutil.virtual_memory().available
         evec_bytes_per_qpt = 16*(3*n_atoms)**2
+        # Divide chunk by 10 for a conservative estimate
         chunk = int(mem/(10*evec_bytes_per_qpt))
         return chunk
 

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -1,5 +1,2 @@
 euphonic>=0.6.0
-psutil
-pytest
-pytest-mock
-coverage
+psutil>=5.4.6

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -1,4 +1,5 @@
 euphonic>=0.6.0
+psutil
 pytest
 pytest-mock
 coverage

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -1,3 +1,4 @@
 euphonic>=0.6.0
 pytest
+pytest-mock
 coverage

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     phonopy_reader : Tests that require the phonopy_reader extra
+    psutil : Tests that require psutil (usually automatic chunking tests)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,3 @@
 [pytest]
 markers =
     phonopy_reader : Tests that require the phonopy_reader extra
-    psutil : Tests that require psutil (usually automatic chunking tests)

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,17 @@ try:
 except ImportError:
     from distutils.core import setup
 
-def get_euphonic_version():
-    # gets the required euphonic version from `min_requirements.txt` file
+def get_required_versions():
+    # gets required module versions from `min_requirements.txt` file
     import os
     curdir = os.path.dirname(os.path.abspath(__file__))
     with open(os.path.join(curdir, 'min_requirements.txt')) as minreq:
-        verstr = [req for req in minreq if 'euphonic' in req]
-    return verstr[0].split('=')[1].strip()
+        reqs = minreq.read().splitlines()
+    # Don't have to account for special case of Euphonic intermediate
+    # versions here (e.g. euphonic>0.6.0) because that indicates a
+    # dev/test version in which case apply_requirements.py should be
+    # used. So just return reqs.
+    return reqs
 
 
 setup(name='euphonic_sqw_models',
@@ -21,6 +25,5 @@ setup(name='euphonic_sqw_models',
       author_email='rebecca.fair@stfc.ac.uk',
       url='https://github.com/pace-neutrons/euphonic_sqw_models',
       packages=['euphonic_sqw_models'],
-      install_requires=['euphonic>=' + get_euphonic_version()],
-      extras_require={'psutil': ['psutil>=0.6.0']}
+      install_requires=get_required_versions(),
      )

--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,5 @@ setup(name='euphonic_sqw_models',
       url='https://github.com/pace-neutrons/euphonic_sqw_models',
       packages=['euphonic_sqw_models'],
       install_requires=['euphonic>=' + get_euphonic_version()],
+      extras_require={'psutil': ['psutil>=0.6.0']}
      )

--- a/test/ci_requirements.txt
+++ b/test/ci_requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-mock
+coverage

--- a/test/euphonic_horace_test.py
+++ b/test/euphonic_horace_test.py
@@ -366,6 +366,7 @@ def test_invalid_kwargs_raises_value_error(kwarg):
     with pytest.raises(ValueError):
         euphonic_sqw_models.CoherentCrystal(fc, **kwarg)
 
+@pytest.mark.psutil
 def test_optimum_chunk():
     quartz_fc = euphonic.ForceConstants.from_castep(quartz[2]['filename'])
     quartz_coh = euphonic_sqw_models.CoherentCrystal(quartz_fc)

--- a/test/euphonic_horace_test.py
+++ b/test/euphonic_horace_test.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 
 import pytest
 import numpy as np
@@ -366,33 +367,50 @@ def test_invalid_kwargs_raises_value_error(kwarg):
     with pytest.raises(ValueError):
         euphonic_sqw_models.CoherentCrystal(fc, **kwarg)
 
-@pytest.mark.psutil
-def test_optimum_chunk():
-    quartz_fc = euphonic.ForceConstants.from_castep(quartz[2]['filename'])
-    quartz_coh = euphonic_sqw_models.CoherentCrystal(quartz_fc)
+class TestChunk:
 
-    nacl_fc = euphonic.ForceConstants.from_json_file(nacl_json[2]['filename'])
-    nacl_coh = euphonic_sqw_models.CoherentCrystal(nacl_fc)
-
-    assert quartz_coh.chunk is not None
-    assert nacl_coh.chunk is not None
-    # Check fewer atoms = larger chunk size
-    assert nacl_coh.chunk > quartz_coh.chunk
-
-@pytest.fixture
-def mocked_psutil(mocker):
-    # Mock import of psutil to raise ModuleNotFound error
-    import builtins
-    real_import = builtins.__import__
-
-    def mocked_import(name, *args, **kwargs):
-        if name == 'psutil':
-            raise ModuleNotFoundError
-        return real_import(name, *args, **kwargs)
-    mocker.patch('builtins.__import__', side_effect=mocked_import)
-
-def test_optimum_chunk_without_psutil_warns_sets_chunk_to_5000(mocked_psutil):
-    quartz_fc = euphonic.ForceConstants.from_castep(quartz[2]['filename'])
-    with pytest.warns(UserWarning):
+    @pytest.mark.psutil
+    def test_optimum_chunk_larger_with_smaller_cell(self):
+        quartz_fc = euphonic.ForceConstants.from_castep(quartz[2]['filename'])
         quartz_coh = euphonic_sqw_models.CoherentCrystal(quartz_fc)
-    assert quartz_coh.chunk == 5000
+
+        nacl_fc = euphonic.ForceConstants.from_json_file(nacl_json[2]['filename'])
+        nacl_coh = euphonic_sqw_models.CoherentCrystal(nacl_fc)
+
+        assert quartz_coh.chunk is not None
+        assert nacl_coh.chunk is not None
+        # Check fewer atoms = larger chunk size
+        assert nacl_coh.chunk > quartz_coh.chunk
+
+    @pytest.mark.psutil
+    def test_optimum_chunk_mocked_psutil_virtualmemory(self, mocker):
+        available_memory = 1e5
+        psutil_virtual_memory = SimpleNamespace()
+        psutil_virtual_memory.available = available_memory
+        mocker.patch('psutil.virtual_memory',
+                     return_value=psutil_virtual_memory)
+
+        quartz_fc = euphonic.ForceConstants.from_castep(quartz[2]['filename'])
+        quartz_coh = euphonic_sqw_models.CoherentCrystal(quartz_fc)
+        n_atoms = 9
+        evec_bytes_per_qpt = 16*(3*n_atoms)**2
+        assert quartz_coh.chunk == int(available_memory/(10*evec_bytes_per_qpt))
+
+    @pytest.fixture
+    def mocked_psutil_notfound(self, mocker):
+        # Mock import of psutil to raise ModuleNotFound error
+        import builtins
+        real_import = builtins.__import__
+
+        def mocked_import(name, *args, **kwargs):
+            if name == 'psutil':
+                raise ModuleNotFoundError
+            return real_import(name, *args, **kwargs)
+        mocker.patch('builtins.__import__', side_effect=mocked_import)
+
+    def test_optimum_chunk_without_psutil_warns_sets_chunk_to_5000(
+            self, mocked_psutil_notfound):
+        quartz_fc = euphonic.ForceConstants.from_castep(quartz[2]['filename'])
+        with pytest.warns(UserWarning):
+            quartz_coh = euphonic_sqw_models.CoherentCrystal(quartz_fc)
+        assert quartz_coh.chunk == 5000

--- a/test/euphonic_horace_test.py
+++ b/test/euphonic_horace_test.py
@@ -369,7 +369,6 @@ def test_invalid_kwargs_raises_value_error(kwarg):
 
 class TestChunk:
 
-    @pytest.mark.psutil
     def test_optimum_chunk_larger_with_smaller_cell(self):
         quartz_fc = euphonic.ForceConstants.from_castep(quartz[2]['filename'])
         quartz_coh = euphonic_sqw_models.CoherentCrystal(quartz_fc)
@@ -382,7 +381,6 @@ class TestChunk:
         # Check fewer atoms = larger chunk size
         assert nacl_coh.chunk > quartz_coh.chunk
 
-    @pytest.mark.psutil
     def test_optimum_chunk_mocked_psutil_virtualmemory(self, mocker):
         available_memory = 1e5
         psutil_virtual_memory = SimpleNamespace()
@@ -395,22 +393,3 @@ class TestChunk:
         n_atoms = 9
         evec_bytes_per_qpt = 16*(3*n_atoms)**2
         assert quartz_coh.chunk == int(available_memory/(10*evec_bytes_per_qpt))
-
-    @pytest.fixture
-    def mocked_psutil_notfound(self, mocker):
-        # Mock import of psutil to raise ModuleNotFound error
-        import builtins
-        real_import = builtins.__import__
-
-        def mocked_import(name, *args, **kwargs):
-            if name == 'psutil':
-                raise ModuleNotFoundError
-            return real_import(name, *args, **kwargs)
-        mocker.patch('builtins.__import__', side_effect=mocked_import)
-
-    def test_optimum_chunk_without_psutil_warns_sets_chunk_to_5000(
-            self, mocked_psutil_notfound):
-        quartz_fc = euphonic.ForceConstants.from_castep(quartz[2]['filename'])
-        with pytest.warns(UserWarning):
-            quartz_coh = euphonic_sqw_models.CoherentCrystal(quartz_fc)
-        assert quartz_coh.chunk == 5000


### PR DESCRIPTION
Addresses https://github.com/pace-neutrons/horace-euphonic-interface/issues/24, this PR should be merged before https://github.com/pace-neutrons/horace-euphonic-interface/pull/32

Allow estimation of automatic chunk size based on available memory (obtained through `psutil.virtual_memory().available`).

I couldn't find a good way to get the available memory in the standard library, so have had to rely on `psutil`. There isn't currently any easy way to set dependencies for `euphonic_sqw_models` beyond what is included in Euphonic, so I've allowed it to be an optional dependency. I'll update the IDAaaS install so that `psutil` is installed into the Euphonic environment. Maybe we can revisit this in the future if we end up needing too many optional dependencies.

Also note that it calculates the number of q-point eigenvectors that would fit into memory, then divides by a factor of 10 (kind of arbitrary). This is largely because I've found on IDAaaS that allocating large Python arrays from Matlab is quite fragile, and seems to crash if a smaller factor is used.